### PR TITLE
Playing media directly when clicking on a content link

### DIFF
--- a/plugin.video.redbulltv2/addon.xml
+++ b/plugin.video.redbulltv2/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.redbulltv2" name="Redbull TV2" version="0.0.6" provider-name="nedge2k">
+<addon id="plugin.video.redbulltv2" name="Redbull TV2" version="0.0.7" provider-name="nedge2k">
 	<requires>
 		<import addon="xbmc.python" version="2.20.0"/>
 		<import addon="script.module.elementtree" version="1.2.7"/>

--- a/plugin.video.redbulltv2/default.py
+++ b/plugin.video.redbulltv2/default.py
@@ -73,7 +73,6 @@ class RedbullTV2():
 		# Try find the specific stream based on the users preferences
 		try:
 			playlists = urllib2.urlopen(url).read()
-			# media_url = re.search("x" + self.resolutions[self.addon.getSetting('video.resolution')] + ",.*\n(.*)",response).group(1)
 			resolutionCode = self.getResolutionCode(self.addon.getSetting('video.resolution'))
 			media_url = re.search(
 				"RESOLUTION=" + resolutionCode + ".*\n(.*)",


### PR DESCRIPTION
Currently all links are folder links, and when clicking on a content link it then goes to another page with a single item, and clicking on that  will play the media. This change allows media links to play content immediately, and also clearly shows which are media links and which are folders in a list:

![image](https://user-images.githubusercontent.com/557065/30039772-f6229ace-91d5-11e7-9fe7-6db595dbb306.png)

I've created this PR against my last PR as it needed some changes from the last one.
